### PR TITLE
Update integration docs to reflect initial associates changes

### DIFF
--- a/source/includes/_02-passfort-data-structure.html.md
+++ b/source/includes/_02-passfort-data-structure.html.md
@@ -118,7 +118,7 @@ This error should be returned when your integration receives a `demo_result`
 value which it doesn't support or does not have demo data implemented.
 
 [api-docs-post-check]: https://developer.passfort.com/api#tag/Checks/paths/~1profiles~1{profile_id}~1checks/post
-[api-docs-openapi-json]: https://identity.passfort.com/api/static/schemas/openapi.json
+[api-docs-openapi-json]: https://identity.passfort.com/api/static/schemas/openapi_v41.json
 
 ## Check charges
 

--- a/source/includes/_03-demo-checks.html.md
+++ b/source/includes/_03-demo-checks.html.md
@@ -216,7 +216,7 @@ supported fields.
 Your integration must return a result as if the company submitted was on record as no 
 longer actively operating.
 
-#### `COMPANY_COUNTRY_OF_INCORPORATION_MISMATCH` <span style="float:right">Required</span>
+#### `COMPANY_COUNTRY_OF_INCORPORATION_MISMATCH`
 
 Your integration must return a result as if the company submitted was on record with a
 different country of incorporation from the one submitted in the check input.
@@ -230,3 +230,21 @@ different name from the one submitted in the check input.
 
 Your integration must return a result as if the company submitted was on record with a
 different number from the one submitted in the check input.
+
+#### `COMPANY_RESIGNED_OFFICER`
+
+Your integration must return a result with at least one associate with all its officer 
+relationships marked with a `FORMER` tenure.
+
+#### `COMPANY_FORMER_SHAREHOLDER
+Your integration must return a result with at least one associate with a shareholder 
+relationship marked with a `FORMER` tenure.
+
+#### `COMPANY_OFFICER_WITH_MULTIPLE_ROLES`
+Your integration must return a result with at least one associate with more than one
+officer relationship.
+
+#### `COMPANY_SHAREHOLDER_WITH_100_PERCENT_OWNERSHIP`
+
+Your integration must return a result with at exactly one associate with a single shareholder
+owning 100% of the company.


### PR DESCRIPTION
Updating to point to v4.1 spec and describing the new demo results. 

We still reference our v4.0 generated documentation in a couple of places since the new spec only includes the CompanyData resource for now. 