### PR TITLE
Make the PARTNER team CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @PassFort/PARTNER


### PR DESCRIPTION
All of the repositories are having their CODEOWNERS file added and this one is designated as being owned by the PARTNER team.

This action was performed as part of a script.

[APPS-483]

[APPS-483]: https://passfort.atlassian.net/browse/APPS-483?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ