### PR TITLE
Updated onetime callback documentation

### DIFF
--- a/source/includes/_one-time-callback-docfetch.html.md.erb
+++ b/source/includes/_one-time-callback-docfetch.html.md.erb
@@ -54,13 +54,26 @@ The `check_template` fields for this check are:
       </td>
     </tr>
     <tr>
-      <td><code>timeout</code></td>
+      <td><code>request_timeout</code></td>
       <td>number</td>
       <td>No</td>
       <td>
         The number of seconds Passfort should wait without a response before
         considering Document fetch checks run through this integration to have
         timed out. Must be an integer. If not specified or set to
+        <code>null</code>, a timeout of 60 seconds is used. This timeout
+        will also be applied to image downloads.
+      </td>
+    </tr>
+    </tr>
+    <tr>
+      <td><code>callback_timeout</code></td>
+      <td>number</td>
+      <td>No</td>
+      <td>
+        The number of seconds Passfort should wait following a callback without 
+        a response before considering Document fetch checks run through this integration 
+        to have timed out. Must be an integer. If not specified or set to
         <code>null</code>, a timeout of 60 seconds is used. This timeout
         will also be applied to image downloads.
       </td>

--- a/source/includes/_one-time-callback-docver.html.md.erb
+++ b/source/includes/_one-time-callback-docver.html.md.erb
@@ -61,14 +61,28 @@ The `check_template` fields for this check are:
       </td>
     </tr>
     <tr>
-      <td><code>timeout</code></td>
+      <td><code>request_timeout</code></td>
       <td>number</td>
       <td>No</td>
       <td>
         The number of seconds Passfort should wait without a response before
-        considering Document verification checks run through this integration to have
+        considering Document fetch checks run through this integration to have
         timed out. Must be an integer. If not specified or set to
-        <code>null</code>, a timeout of 60 seconds is used.
+        <code>null</code>, a timeout of 60 seconds is used. This timeout
+        will also be applied to image downloads.
+      </td>
+    </tr>
+    </tr>
+    <tr>
+      <td><code>callback_timeout</code></td>
+      <td>number</td>
+      <td>No</td>
+      <td>
+        The number of seconds Passfort should wait following a callback without 
+        a response before considering Document fetch checks run through this integration 
+        to have timed out. Must be an integer. If not specified or set to
+        <code>null</code>, a timeout of 60 seconds is used. This timeout
+        will also be applied to image downloads.
       </td>
     </tr>
   </tbody>

--- a/source/includes/_one-time-callback-docver.html.md.erb
+++ b/source/includes/_one-time-callback-docver.html.md.erb
@@ -66,7 +66,7 @@ The `check_template` fields for this check are:
       <td>No</td>
       <td>
         The number of seconds Passfort should wait without a response before
-        considering Document fetch checks run through this integration to have
+        considering Document verification checks run through this integration to have
         timed out. Must be an integer. If not specified or set to
         <code>null</code>, a timeout of 60 seconds is used. This timeout
         will also be applied to image downloads.

--- a/source/json/config/callback_document_fetch.json
+++ b/source/json/config/callback_document_fetch.json
@@ -2,7 +2,8 @@
     "check_type": "DOCUMENT_FETCH",
     "check_template": {
         "type": "ONE_TIME_CALLBACK",
-        "timeout": 5
+        "request_timeout": 15,
+        "callback_timeout": 15
     },
     "pricing": {
         "supports_reselling": true,

--- a/source/json/config/callback_document_verification.json
+++ b/source/json/config/callback_document_verification.json
@@ -2,7 +2,8 @@
     "check_type": "DOCUMENT_VERIFICATION",
     "check_template": {
         "type": "ONE_TIME_CALLBACK",
-        "timeout": 5
+        "request_timeout": 15,
+        "callback_timeout": 15
     },
     "pricing": {
         "supports_reselling": true,


### PR DESCRIPTION
As per ticket SPT-89 I have updated the documentation and examples to include the config timeouts associated with one time callbacks.

This was changing the timeout field, to be request_timeout and callback_timeout.